### PR TITLE
Fix description for the categories format

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,7 @@
                 <textarea id="data" cols=80 rows=10></textarea>
             </div>
             <div>
-                <label>Categories (separated by spaces):</label>
+                <label>Categories (separated by commas):</label>
                 <input type="text" id="categories" />
             </div>
             <div>


### PR DESCRIPTION
Categories are separated by commas, not spaces.
